### PR TITLE
Update RecordChart.js

### DIFF
--- a/src/components/RecordChart.js
+++ b/src/components/RecordChart.js
@@ -22,7 +22,7 @@ const chartOptions = {
         title: {
             text: 'Portals',
         },
-        max: 12,
+        max: 10,
     },
     fill: {
         opacity: 1,


### PR DESCRIPTION
Lowest portal record is 9 in Conversion intro, so chaning the max to 10 wond skip any values and make the records chart look nicer.